### PR TITLE
Properly overwrite existing models using internal Django API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,30 @@
-# Poetry Template
+# django-ormsgpack
 
-Django app template, using `poetry-python` as dependency manager.
+**the missing Model serializer for Django cache and celery.**
 
-This project is a template that can be cloned and re-used for redistributable apps.
+`django-ormsgpack` provides serialization of Django Model class instances,
+backed by [ormsgpack](https://github.com/aviramha/ormsgpack), resulting in serialization
+far faster than [pickle](https://docs.python.org/dev/library/pickle.html#module-pickle),
+and much smaller serialized values than pickle provides.
 
-It includes the following:
 
-* `poetry` for dependency management
-* `isort`, `black`, `pylint` and `flake8` linting
-* `pre-commit` to run linting
-* `mypy` for type checking
-* `tox` and `travis` for builds and CI
-
-There are default config files for the linting and mypy.
-
-## Principles
-
-The motivation for this project is to provide a consistent set of standards across all YunoJuno public Python/Django projects. The principles we want to encourage are:
-
-* Simple for developers to get up-and-running:
-    * Install all dev dependencies in an isolated environment
-    * Run complete tox suite locally
-* Consistent style:
-    * Common formatting with `isort` and `black`
-    * Common patterns with `pylint` and `flake8`
-* Full type hinting
-
-## Versioning
-
-It's 2020, Python2 is officially deprecated, and we run our core platform on recent releases (Python 3.8 and Django 2.2 at the time of writing). Taking out lead from Django itself, we only support Python 3.8/7/6 and Django 2.2/3.0. As new versions arrive we will deprecate older versions at the point at which maintaining becomes a burden. Typically this is when we start to have to incorporate conditional imports into modules. When an older version of Python / Django is deprecated, the last supported version will be tagged as such. In the unlikely event that any bug fixes need to be applied to an old version, they will be done on a branch off the last known good version. They will not be released to PyPI.
-
-## Tests
-
-#### Tests package
-The package tests themselves are _outside_ of the main library code, in a package that is itself a Django app (it contains `models`, `settings`, and any other artifacts required to run the tests (e.g. `urls`).) Where appropriate, this test app may be runnable as a Django project - so that developers can spin up the test app and see what admin screens look like, test migrations, etc.
-
-#### Running tests
-The tests themselves use `pytest` as the test runner. If you have installed the `poetry` evironment, you can run them thus:
+## Installation
 
 ```
-$ poetry run pytest
+pip install django-ormsgpack
 ```
 
-or 
+## Mark up your models
 
 ```
-$ poetry shell
-(my_app) $ pytest
+from django.db import Models
+from django_ormsgpack import serializable_model
+
+@serializable_model
+class MyModel(models.Model):
+   class Serialize:
+       pass
+
+
+
 ```
-
-The full suite is controlled by `tox`, which contains a set of environments that will format (`fmt`), lint, and test against all support Python + Django version combinations.
-
-```
-$ tox
-...
-______________________ summary __________________________
-  fmt: commands succeeded
-  lint: commands succeeded
-  mypy: commands succeeded
-  py36-django22: commands succeeded
-  py36-django30: commands succeeded
-  py37-django22: commands succeeded
-  py37-django30: commands succeeded
-  py38-django22: commands succeeded
-  py38-django30: commands succeeded
-```
-
-#### CI
-
-There is a `.travis.yml` file that can be used as a baseline to run all of the tests on Travis.

--- a/django_ormsgpack/__init__.py
+++ b/django_ormsgpack/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.1.0"
 from .model import *
-from .registry import register_serializable
+from .registry import serializable_model

--- a/django_ormsgpack/model.py
+++ b/django_ormsgpack/model.py
@@ -43,7 +43,7 @@ class SerializationProgrammingError(SerializationError):
 ERROR_UPDATE_FIELDS = "To save a deserialized copy of a model, the instance must either: (a) be of a class that is configured to serialize all of its fields, (b) provide `update_fields` with a subset of the serialized fields, or (c) provide `force_insert` or `force_update`."
 
 
-class SerializableModel(Model):
+class SerializableModel(Model, Serializable):
     """
     Enables serialization with django_ormsgpack.
     """
@@ -145,6 +145,10 @@ class SerializableModel(Model):
                 traceback.print_exc()
                 raise SerializationError() from ex
 
+    @classmethod
+    def deserialize(cls: T, val: bytes) -> T:
+        return cls.from_tuple(ormsgpack.unpackb(val))  # pylint: disable=c-extension-no-member
+
     def to_tuple(self) -> tuple:
         """
         Convert the object to list based on configuration.
@@ -158,6 +162,9 @@ class SerializableModel(Model):
             except Exception as ex:
                 traceback.print_exc()
                 raise SerializationError() from ex
+
+    def serialize(self) -> bytes:
+        return ormsgpack.packb(self.to_tuple())
 
     class Meta:
         abstract = True

--- a/django_ormsgpack/model.py
+++ b/django_ormsgpack/model.py
@@ -43,7 +43,8 @@ class SerializationProgrammingError(SerializationError):
 ERROR_UPDATE_FIELDS = "To save a deserialized copy of a model, the instance must either: (a) be of a class that is configured to serialize all of its fields, (b) provide `update_fields` with a subset of the serialized fields, or (c) provide `force_insert` or `force_update`."
 
 
-class SerializableModel(Model, Serializable):
+@Serializable.register  # type: ignore
+class SerializableModel(Model):
     """
     Enables serialization with django_ormsgpack.
     """
@@ -146,7 +147,7 @@ class SerializableModel(Model, Serializable):
                 raise SerializationError() from ex
 
     @classmethod
-    def deserialize(cls: T, val: bytes) -> T:
+    def deserialize(cls: T, val: bytes) -> T:  # type: ignore
         return cls.from_tuple(
             ormsgpack.unpackb(val)
         )  # pylint: disable=c-extension-no-member

--- a/django_ormsgpack/model.py
+++ b/django_ormsgpack/model.py
@@ -147,7 +147,9 @@ class SerializableModel(Model, Serializable):
 
     @classmethod
     def deserialize(cls: T, val: bytes) -> T:
-        return cls.from_tuple(ormsgpack.unpackb(val))  # pylint: disable=c-extension-no-member
+        return cls.from_tuple(
+            ormsgpack.unpackb(val)
+        )  # pylint: disable=c-extension-no-member
 
     def to_tuple(self) -> tuple:
         """

--- a/django_ormsgpack/model.py
+++ b/django_ormsgpack/model.py
@@ -43,7 +43,7 @@ class SerializationProgrammingError(SerializationError):
 ERROR_UPDATE_FIELDS = "To save a deserialized copy of a model, the instance must either: (a) be of a class that is configured to serialize all of its fields, (b) provide `update_fields` with a subset of the serialized fields, or (c) provide `force_insert` or `force_update`."
 
 
-@Serializable.register  # type: ignore
+@Serializable.register
 class SerializableModel(Model):
     """
     Enables serialization with django_ormsgpack.

--- a/django_ormsgpack/registry.py
+++ b/django_ormsgpack/registry.py
@@ -76,6 +76,7 @@ def serializable_model(decorated: R) -> Union[R, Serializable]:
 
         ModelClass.__doc__ = decorated.__doc__
         decorated = ModelClass  # type: ignore
+        Serializable.register(decorated)  # type: ignore
 
     id_num = adler32(class_fqname(decorated).encode(ASCII))
     ID_TO_CLASS[id_num] = decorated

--- a/django_ormsgpack/registry.py
+++ b/django_ormsgpack/registry.py
@@ -76,7 +76,7 @@ def serializable_model(decorated: R) -> Union[R, Serializable]:
 
         ModelClass.__doc__ = decorated.__doc__
         decorated = ModelClass  # type: ignore
-        Serializable.register(decorated)  # type: ignore
+        Serializable.register(decorated)
 
     id_num = adler32(class_fqname(decorated).encode(ASCII))
     ID_TO_CLASS[id_num] = decorated

--- a/django_ormsgpack/serializable.py
+++ b/django_ormsgpack/serializable.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, NewType, Type, TypeVar
+from typing import Any, List, NewType, Type, TypeVar, Optional
 
 
-class Serializable(ABC):
-    _serializer_id = 0
+class Serializable:
+    _serializer_id: Optional[int] = None
 
     @classmethod
     @abstractmethod

--- a/django_ormsgpack/serializable.py
+++ b/django_ormsgpack/serializable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, NewType, Type, TypeVar, Optional
+from typing import Any, List, NewType, Optional, Type, TypeVar
 
 
 class Serializable:

--- a/django_ormsgpack/serializable.py
+++ b/django_ormsgpack/serializable.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, List, NewType, Optional, Type, TypeVar
 
 
-class Serializable:
+class Serializable(ABC):
     _serializer_id: Optional[int] = None
 
     @classmethod

--- a/my_app/models.py
+++ b/my_app/models.py
@@ -8,10 +8,11 @@ from django.db.models import (
     Model,
     UUIDField,
 )
-from django_ormsgpack import SerializableModel, register_serializable
+from django_ormsgpack import serializable_model
 
 
-class ATestModel(SerializableModel, Model):
+@serializable_model
+class ATestModel(Model):
     id = UUIDField(primary_key=True, default=uuid4, editable=False)
     char_field = CharField(max_length=255)
     date_field = DateTimeField()
@@ -24,18 +25,18 @@ class ATestModel(SerializableModel, Model):
         fields = {"char_field", "date_field", "decimal_field", "int_field", "zorg"}
 
 
-@register_serializable
+@serializable_model
 class BTestModel(ATestModel):
     ...
 
 
-@register_serializable
+@serializable_model
 class CTestModel(BTestModel):
     id = IntegerField(primary_key=True)
 
 
-@register_serializable
-class Ticket(SerializableModel, Model):
+@serializable_model
+class Ticket(Model):
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     screening = models.ForeignKey(
         BTestModel, related_name="screenings", on_delete=models.PROTECT


### PR DESCRIPTION
The initial method of simply defining a new model class from within the
`@serializable_model` decorator will not work.  Model classes need to be
defined once, and within the correct module.

The solution given here effectively works around the issue by expressly
removing the superclass model from the Django models registry, and
creating a new class that inherits the same name and module as the
superclass.

This suffers from the following inadequacies:

1. The superclass must be marked as a proxy in order to avoid being
   interpreted as a multi-table inheritance scheme.
2. Being marked as a proxy means that multi-table inheritance is not
   possible.
3. Overwriting the superclass in the registry seems bound to create some
   sort of bug down the line.

For now the solution is committed as-is, with the hope of finding a
separate solution that will FULLY replace the original class in the
registry.  Let us see if that can be done via some combination of
manually deleting the `_meta` object, or marking the `Meta` class with
`abstract = True`, on the decorated superclass.

Closes #4 